### PR TITLE
Fix broken regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-show-downloader",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-show-downloader",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Web app for automatically downloading new episodes of TV shows",
   "main": "dist/index.js",
   "scripts": {

--- a/src/checkTorrents.ts
+++ b/src/checkTorrents.ts
@@ -106,8 +106,6 @@ export const getEpisodesToDownload = (
             let alreadyHave = false;
             for (const torrentName of torrentNames) {
               if (wanted.episodeName === torrentName) {
-                // tslint:disable-next-line: no-console
-                console.log(torrentName);
                 alreadyHave = true;
                 break;
               }

--- a/src/rssFilter.ts
+++ b/src/rssFilter.ts
@@ -13,17 +13,16 @@ export const rssFilter = (
 ): ShowTuple[] => {
   const wantedLinks = new Array<ShowTuple>();
 
-  for (const feed of feeds) {
-    for (const show of shows) {
+  for (const show of shows) {
+    for (const feed of feeds) {
       let bestShowMatch: Parser.Item;
+      let regex: RegExp;
+      // specific regexes for known providers
+      regex = new RegExp(`(\\[.*\\])? ?${show} - \\d+.*`, "i");
+      if (feed.link === "https://nyaa.si/") {
+        regex = new RegExp(`(\\[.*\\])? ?${show} - \\d+ \\[1080p\\].*`, "i");
+      }
       for (const item of feed.items) {
-        let regex: RegExp;
-        // specific regexes for known providers
-        regex = new RegExp(`(\[.*\])? ?${show} - \d*.*`, "i");
-        if (feed.link === "https://nyaa.si/") {
-          regex = new RegExp(`(\[.*\])? ?${show} - \d+ \[1080p\].*`, "i");
-        }
-
         if (regex.test(item.title)) {
           // for Nyaa torrents (where seeders are reported) grab only the
           // highest-seeded torrent


### PR DESCRIPTION
Fixed a bug with the regular expressions used to match torrent names. RegExes built from JavaScript strings need to be doubly escaped.